### PR TITLE
Require Node.js 12 and support `BigInt`s

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 14
           - 12
-          - 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,12 +5,12 @@ declare namespace inRange {
 
 		@default 0
 		*/
-		readonly start?: number;
+		readonly start?: number | BigInt;
 
 		/**
 		End of the range.
 		*/
-		readonly end: number;
+		readonly end: number | BigInt;
 	}
 }
 
@@ -34,6 +34,6 @@ inRange(30, {end: 10}); // 0..10
 //=> false
 ```
 */
-declare function inRange(number: number, range: inRange.Range): boolean;
+declare function inRange(number: number | BigInt, range: inRange.Range): boolean;
 
 export = inRange;

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ Check if a number is in a given range.
 
 @example
 ```
-import inRange = require('in-range');
+import inRange from 'in-range';
 
 inRange(30, {end: 100}); // 0..100
 //=> true
@@ -36,4 +36,4 @@ inRange(30, {end: 10}); // 0..10
 */
 declare function inRange(number: number | BigInt, range: inRange.Range): boolean;
 
-export = inRange;
+export default inRange;

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,10 @@ inRange(30, {start: 100, end: 10}); // 10..100
 
 inRange(30, {end: 10}); // 0..10
 //=> false
+
+// Any input can be a BigInt
+inRange(30n, {start: 100n, end: 10}); // 10..100
+//=> true
 ```
 */
 declare function inRange(number: number | BigInt, range: inRange.Range): boolean;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const max = (left, right) => left > right ? left : right;
 
 const isNumberOrBigInt = value => ['number', 'bigint'].includes(typeof value);
 
-module.exports = (number, {start = 0, end}) => {
+const inRange = (number, {start = 0, end}) => {
 	if (
 		!isNumberOrBigInt(number) ||
 		!isNumberOrBigInt(number) ||
@@ -16,3 +16,5 @@ module.exports = (number, {start = 0, end}) => {
 
 	return number >= min(start, end) && number <= max(end, start);
 };
+
+export default inRange;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,18 @@
 'use strict';
 
+const min = (left, right) => left < right ? left : right;
+const max = (left, right) => left > right ? left : right;
+
+const isNumberOrBigInt = value => ['number', 'bigint'].includes(typeof value);
+
 module.exports = (number, {start = 0, end}) => {
 	if (
-		typeof number !== 'number' ||
-		typeof start !== 'number' ||
-		typeof end !== 'number'
+		!isNumberOrBigInt(number) ||
+		!isNumberOrBigInt(number) ||
+		!isNumberOrBigInt(number)
 	) {
-		throw new TypeError('Expected all arguments to be numbers');
+		throw new TypeError('Expected each argument to be either a number or a BigInt');
 	}
 
-	return number >= Math.min(start, end) && number <= Math.max(end, start);
+	return number >= min(start, end) && number <= max(end, start);
 };

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const isNumberOrBigInt = value => ['number', 'bigint'].includes(typeof value);
 const inRange = (number, {start = 0, end}) => {
 	if (
 		!isNumberOrBigInt(number) ||
-		!isNumberOrBigInt(number) ||
-		!isNumberOrBigInt(number)
+		!isNumberOrBigInt(start) ||
+		!isNumberOrBigInt(end)
 	) {
 		throw new TypeError('Expected each argument to be either a number or a BigInt');
 	}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const min = (left, right) => left < right ? left : right;
 const max = (left, right) => left > right ? left : right;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
-import inRange = require('.');
+import inRange from './index.js';
 
 expectType<boolean>(inRange(30, {end: 100}));
 expectType<boolean>(inRange(30, {start: 10, end: 100}));
+// @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+expectType<boolean>(inRange(30n, {start: 10n, end: 100n}));

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
+	"type": "module",
 	"engines": {
-		"node": ">=10.4"
+		"node": ">=12"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"type": "module",
+	"exports": "./index.js",
 	"engines": {
 		"node": ">=12"
 	},
@@ -25,7 +26,8 @@
 		"range",
 		"number",
 		"check",
-		"is"
+		"is",
+		"bigint"
 	],
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
+		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
 	"exports": "./index.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10.4"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -27,8 +27,8 @@
 		"is"
 	],
 	"devDependencies": {
-		"ava": "^1.4.1",
-		"tsd": "^0.7.2",
-		"xo": "^0.24.0"
+		"ava": "^3.15.0",
+		"tsd": "^0.14.0",
+		"xo": "^0.37.1"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,11 @@
 
 > Check if a number is in a given range
 
-
 ## Install
 
 ```
 $ npm install in-range
 ```
-
 
 ## Usage
 
@@ -26,8 +24,11 @@ inRange(30, {start: 100, end: 10}); // 10..100
 
 inRange(30, {end: 10}); // 0..10
 //=> false
-```
 
+// Any input can be a BigInt
+inRange(30n, {start: 100n, end: 10}); // 10..100
+//=> true
+```
 
 ## API
 
@@ -35,28 +36,23 @@ inRange(30, {end: 10}); // 0..10
 
 #### number
 
-Type: `number`
+Type: `number | BigInt`
 
 Number to check.
 
 #### range
 
-Type: `Object`
+Type: `object`
 
 ##### start
 
-Type: `number`<br>
+Type: `number | BigInt`\
 Default: `0`
 
 Start of the range.
 
 ##### end
 
-Type: `number`
+Type: `number | BigInt`
 
 End of the range.
-
-
-## License
-
-MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ $ npm install in-range
 ## Usage
 
 ```js
-const inRange = require('in-range');
+import inRange from 'in-range';
 
 inRange(30, {end: 100}); // 0..100
 //=> true

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-const test = require('ava');
-const inRange = require('.');
+import test from 'ava';
+import inRange from './index.js';
 
 test('main', t => {
 	t.true(inRange(0, {end: 0}));

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-import test from 'ava';
-import inRange from '.';
+const test = require('ava');
+const inRange = require('.');
 
 test('main', t => {
 	t.true(inRange(0, {end: 0}));
@@ -8,11 +8,19 @@ test('main', t => {
 	t.true(inRange(1, {start: 0, end: 1}));
 	t.true(inRange(2, {start: 0, end: 2}));
 	t.true(inRange(5, {start: 0, end: 10}));
-	t.true(inRange(10, {start: -Infinity, end: Infinity}));
-	t.true(inRange(-10, {start: -Infinity, end: Infinity}));
+	t.true(inRange(10, {start: Number.NEGATIVE_INFINITY, end: Number.POSITIVE_INFINITY}));
+	t.true(inRange(-10, {start: Number.NEGATIVE_INFINITY, end: Number.POSITIVE_INFINITY}));
 	t.true(inRange(-1, {start: -10, end: 10}));
 	t.true(inRange(1.5, {start: 1.1, end: 1.7}));
 	t.true(inRange(1.5, {start: 1.1, end: 1.7}));
 	t.true(inRange(5, {start: 10, end: 1}));
 	t.false(inRange(3, {start: 1, end: 2}));
+});
+
+test('bigint support', t => {
+	t.true(inRange(5, {end: 10n}));
+	t.true(inRange(1, {start: 0n, end: 1n}));
+	t.true(inRange(2, {start: 0, end: 2n}));
+	t.true(inRange(5n, {start: 0n, end: 10}));
+	t.true(inRange(10n, {start: Number.NEGATIVE_INFINITY, end: Number.POSITIVE_INFINITY}));
 });


### PR DESCRIPTION
Node.js 10.4 is the version `BigInt`s were added however we don't actually need to bump the minimum version since the code is still backwards compatible. On the other side of the scale, we could instead make the jump to hyperspace (Node.js 12).

When trying to add type tests, I'm getting this error:

```sh
  index.test-d.ts:6:28
  ×  6:28  BigInt literals are not available when targeting lower than ES2020.
```

Fixes: #3 